### PR TITLE
Remove the references to AFHTTPRequestOperation.m/h in the plugin.xml

### DIFF
--- a/plugin.xml
+++ b/plugin.xml
@@ -56,9 +56,6 @@ SOFTWARE.
         <header-file src="src/ios/BaseClient.h" />
         <source-file src="src/ios/BaseClient.m" />
 
-        <header-file src="src/ios/AFNetworking/AFHTTPRequestOperation.h" />
-        <source-file src="src/ios/AFNetworking/AFHTTPRequestOperation.m" />
-
         <header-file src="src/ios/AFNetworking/AFHTTPRequestOperationManager.h" />
         <source-file src="src/ios/AFNetworking/AFHTTPRequestOperationManager.m" />
 

--- a/src/android/com/adobe/phonegap/fetch/FetchPlugin.java
+++ b/src/android/com/adobe/phonegap/fetch/FetchPlugin.java
@@ -109,6 +109,7 @@ public class FetchPlugin extends CordovaPlugin {
                             e.printStackTrace();
                         }
 
+                        Log.v(LOG_TAG, "HTTP code: " + response.code());
                         Log.v(LOG_TAG, "returning: " + result.toString());
 
                         callbackContext.sendPluginResult(new PluginResult(PluginResult.Status.OK, result));


### PR DESCRIPTION
After updating to AFNetworking 3.0.1, the files AFHTTPRequestOperation.m/h are no longer used. In addition, I have added a log to print the http response code.
