### PR TITLE
Remove the references to non-existing files in the plugin.xml for iOS.

### DIFF
--- a/plugin.xml
+++ b/plugin.xml
@@ -56,12 +56,6 @@ SOFTWARE.
         <header-file src="src/ios/BaseClient.h" />
         <source-file src="src/ios/BaseClient.m" />
 
-        <header-file src="src/ios/AFNetworking/AFHTTPRequestOperation.h" />
-        <source-file src="src/ios/AFNetworking/AFHTTPRequestOperation.m" />
-
-        <header-file src="src/ios/AFNetworking/AFHTTPRequestOperationManager.h" />
-        <source-file src="src/ios/AFNetworking/AFHTTPRequestOperationManager.m" />
-
         <header-file src="src/ios/AFNetworking/AFHTTPSessionManager.h" />
         <source-file src="src/ios/AFNetworking/AFHTTPSessionManager.m" />
 
@@ -72,9 +66,6 @@ SOFTWARE.
 
         <header-file src="src/ios/AFNetworking/AFSecurityPolicy.h" />
         <source-file src="src/ios/AFNetworking/AFSecurityPolicy.m" />
-
-        <header-file src="src/ios/AFNetworking/AFURLConnectionOperation.h" />
-        <source-file src="src/ios/AFNetworking/AFURLConnectionOperation.m" />
 
         <header-file src="src/ios/AFNetworking/AFURLRequestSerialization.h" />
         <source-file src="src/ios/AFNetworking/AFURLRequestSerialization.m" />

--- a/src/android/com/adobe/phonegap/fetch/FetchPlugin.java
+++ b/src/android/com/adobe/phonegap/fetch/FetchPlugin.java
@@ -109,6 +109,7 @@ public class FetchPlugin extends CordovaPlugin {
                             e.printStackTrace();
                         }
 
+                        Log.v(LOG_TAG, "HTTP code: " + response.code());
                         Log.v(LOG_TAG, "returning: " + result.toString());
 
                         callbackContext.sendPluginResult(new PluginResult(PluginResult.Status.OK, result));


### PR DESCRIPTION
After @aporat's update to AFNetworking 3.0.1, some deleted files were
still being referred in the plugin.xml. This commit removes these
references.

In addition, I have added code to print the http code of the response
because this helps developers to debug during the development process,
specially when using RESTFull APIs.
