### PR TITLE
Fix the reference to the AFURLSessionManager.h in the AFNetworkActivityLogger.m.

### DIFF
--- a/src/ios/AFNetworkActivityLogger/AFNetworkActivityLogger.m
+++ b/src/ios/AFNetworkActivityLogger/AFNetworkActivityLogger.m
@@ -21,7 +21,7 @@
 // THE SOFTWARE.
 
 #import "AFNetworkActivityLogger.h"
-#import <AFNetworking/AFURLSessionManager.h>
+#import "AFURLSessionManager.h"
 #import <objc/runtime.h>
 
 static NSURLRequest * AFNetworkRequestFromNotification(NSNotification *notification) {


### PR DESCRIPTION
After @aporat's update to AFNetworking version, the reference to the
AFURLSessionManager.h was wrong, causing a building error for iOS. This
commit fix this problem.
