### PR TITLE
Support for multiple cookies (Related #3)

### DIFF
--- a/src/android/com/adobe/phonegap/fetch/FetchPlugin.java
+++ b/src/android/com/adobe/phonegap/fetch/FetchPlugin.java
@@ -104,16 +104,9 @@ public class FetchPlugin extends CordovaPlugin {
 
                             if (responseHeaders != null ) {
                                 for (int i = 0; i < responseHeaders.size(); i++) {
-                                    if (allHeaders.has(responseHeaders.name(i))) {
-                                        Object intervention = allHeaders.get(responseHeaders.name(i));
-                                        if (intervention instanceof String) {
-                                            JSONArray innerArray = new JSONArray();
-                                            innerArray.put(((String) intervention));
-                                            innerArray.put(responseHeaders.value(i));
-                                            allHeaders.put(responseHeaders.name(i), innerArray);
-                                        } else if (intervention instanceof JSONArray) {
-                                            ((JSONArray) intervention).put(responseHeaders.value(i));
-                                        }
+                                    if (responseHeaders.name(i).compareToIgnoreCase("set-cookie") == 0 &&
+                                        allHeaders.has(responseHeaders.name(i))) {
+                                        allHeaders.put(responseHeaders.name(i), allHeaders.get(responseHeaders.name(i)) + ",\n" + responseHeaders.value(i));
                                         continue;
                                     }
                                     allHeaders.put(responseHeaders.name(i), responseHeaders.value(i));

--- a/src/android/com/adobe/phonegap/fetch/FetchPlugin.java
+++ b/src/android/com/adobe/phonegap/fetch/FetchPlugin.java
@@ -104,6 +104,18 @@ public class FetchPlugin extends CordovaPlugin {
 
                             if (responseHeaders != null ) {
                                 for (int i = 0; i < responseHeaders.size(); i++) {
+                                    if (allHeaders.has(responseHeaders.name(i))) {
+                                        Object intervention = allHeaders.get(responseHeaders.name(i));
+                                        if (intervention instanceof String) {
+                                            JSONArray innerArray = new JSONArray();
+                                            innerArray.put(((String) intervention));
+                                            innerArray.put(responseHeaders.value(i));
+                                            allHeaders.put(responseHeaders.name(i), innerArray);
+                                        } else if (intervention instanceof JSONArray) {
+                                            ((JSONArray) intervention).put(responseHeaders.value(i));
+                                        }
+                                        continue;
+                                    }
                                     allHeaders.put(responseHeaders.name(i), responseHeaders.value(i));
                                 }
                             }


### PR DESCRIPTION
This pull request support for multiple "Set-Cookie" Headers. This changes affect only android plugin. iOS Version works very well, but android version always only shown **last cookie header**.

If Server sent multiple cookies, for example:
```
Date: Thu, 26 Nov 2015 23:07:42 GMT
Server: Apache/2.4.16 (Unix)
Set-Cookie: CookieTesteName1=CookieTesteValue1; expires=Fri, 27-Nov-2015 00:07:42 GMT; Max-Age=3600; path=/folder; domain=.domain.com; secure
Set-Cookie: CookieTesteName2=CookieTesteValue2; expires=Fri, 27-Nov-2015 00:07:42 GMT; Max-Age=3600; path=/folder; domain=.domain.com; secure
CustomHeaderName: CustomHeaderValue
Content-Length: 2397
Keep-Alive: timeout=5, max=100
Connection: Keep-Alive
Content-Type: text/html
```

Then, header json being below shown.

```JSON
{
  "Date": "Thu, 26 Nov 2015 23:07:42 GMT",
  "Server": "Apache/2.4.16 (Unix)",
  "Set-Cookie": "CookieTesteName2=CookieTesteValue2; expires=Fri, 27-Nov-2015 00:07:42 GMT; Max-Age=3600; path=/folder; domain=.domain.com; secure, 
CookieTesteName1=CookieTesteValue1; expires=Fri, 27-Nov-2015 00:07:42 GMT; Max-Age=3600; path=/folder; domain=.domain.com; secure" ...
}
```

Each ``Set-Cookie`` headers Be distinguished Comma and line feed (,\n)