### PR TITLE
Improve Fetch API compatibility by making response implement Body Interface

### DIFF
--- a/src/android/com/adobe/phonegap/fetch/FetchPlugin.java
+++ b/src/android/com/adobe/phonegap/fetch/FetchPlugin.java
@@ -109,7 +109,9 @@ public class FetchPlugin extends CordovaPlugin {
                             }
 
                             result.put("headers", allHeaders);
-                            result.put("statusText", response.body().string());
+
+                            result.put("body", response.body().string());
+                            result.put("statusText", response.message());
                             result.put("status", response.code());
                             result.put("url", response.request().urlString());
 

--- a/src/ios/FetchPlugin.m
+++ b/src/ios/FetchPlugin.m
@@ -44,7 +44,7 @@
     }
     
     if (responseObject !=nil && [responseObject isKindOfClass:[NSData class]]) {
-      [result setObject:[[NSString alloc] initWithData:responseObject encoding:NSUTF8StringEncoding] forKey:@"statusText"];
+      [result setObject:[[NSString alloc] initWithData:responseObject encoding:NSUTF8StringEncoding] forKey:@"body"];
     }
     
     CDVPluginResult *pluginResult = [CDVPluginResult resultWithStatus:CDVCommandStatus_OK messageAsDictionary:result];

--- a/www/fetch.js
+++ b/www/fetch.js
@@ -274,7 +274,6 @@
 
     this._initBody(bodyInit)
     this.type = 'default'
-    this.url = null
     this.status = options.status
     this.ok = this.status >= 200 && this.status < 300
     this.statusText = options.statusText
@@ -314,7 +313,9 @@
           url: response.url
         }
 
-        resolve(options);
+        var fetchResponse = new Response(response.body, options)
+        resolve(fetchResponse);
+
       }, function(response) {
         reject(new TypeError('Network request failed'))
 


### PR DESCRIPTION
This PR improve the response object to follow the Body interface so that subsequent calls of response.json() will not fail with undefined and also move the response from statusText (which should return the HTTP response text such as OK for HTTP 200) to a separate body object.