### PR TITLE
Add support for Blob responses on iOS

### DIFF
--- a/src/ios/FetchPlugin.m
+++ b/src/ios/FetchPlugin.m
@@ -44,7 +44,12 @@
     }
     
     if (responseObject !=nil && [responseObject isKindOfClass:[NSData class]]) {
-      [result setObject:[[NSString alloc] initWithData:responseObject encoding:NSUTF8StringEncoding] forKey:@"body"];
+      NSString *body = [[NSString alloc] initWithData:responseObject encoding:NSUTF8StringEncoding];
+      if (body == nil) {
+          body = [responseObject base64EncodedStringWithOptions:0];
+          [result setObject:[NSNumber numberWithBool:true] forKey:@"isBlob"];
+      }
+      [result setObject:body forKey:@"body"];
     }
     
     CDVPluginResult *pluginResult = [CDVPluginResult resultWithStatus:CDVCommandStatus_OK messageAsDictionary:result];

--- a/www/fetch.js
+++ b/www/fetch.js
@@ -111,6 +111,30 @@
     return fileReaderReady(reader)
   }
 
+  function b64toBlob(b64Data, contentType, sliceSize) {
+    contentType = contentType || ''
+    sliceSize = sliceSize || 512
+
+    var byteCharacters = atob(b64Data);
+    var byteArrays = []
+
+    for (var offset = 0; offset < byteCharacters.length; offset += sliceSize) {
+      var slice = byteCharacters.slice(offset, offset + sliceSize)
+
+      var byteNumbers = new Array(slice.length);
+      for (var i = 0; i < slice.length; i++) {
+        byteNumbers[i] = slice.charCodeAt(i)
+      }
+
+      var byteArray = new Uint8Array(byteNumbers)
+
+      byteArrays.push(byteArray)
+    }
+
+    var blob = new Blob(byteArrays, {type: contentType})
+    return blob
+  }
+
   var support = {
     blob: 'FileReader' in self && 'Blob' in self && (function() {
       try {
@@ -313,7 +337,8 @@
           url: response.url
         }
 
-        var fetchResponse = new Response(response.body, options)
+        var body = response.isBlob ? b64toBlob(response.body) : response.body
+        var fetchResponse = new Response(body, options)
         resolve(fetchResponse);
 
       }, function(response) {
@@ -328,5 +353,3 @@
   module.exports = cordovaFetch.fetch;
 
 })();
-
-


### PR DESCRIPTION
This is a very basic implementation and it only returns a `Blob` if converting the response to an `NSString` fails. Obviously, a more robust solution would be preferred, but this seems to be enough for my use-case.

The `b64toBlob` function was blatantly copied from the awesome [b64-to-blob](https://github.com/jeremybanks/b64-to-blob) NPM module.