### PR TITLE
Update fetch.js - Copy header if it is windows.Headers object AND also added setTimeout

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,9 +18,7 @@ MIT
 The plugin conforms to the Cordova plugin specification, it can be installed
 using the Cordova / Phonegap command line interface.
 
-    phonegap plugin add https://github.com/aporat/cordova-plugin-fetch.git
-
-    cordova plugin add https://github.com/aporat/cordova-plugin-fetch.git
+    cordova plugin add https://github.com/8bhsolutions/cordova-plugin-fetch.git
 
 ## Usage
 

--- a/src/android/com/adobe/phonegap/fetch/FetchPlugin.java
+++ b/src/android/com/adobe/phonegap/fetch/FetchPlugin.java
@@ -19,6 +19,7 @@ import org.json.JSONException;
 import org.json.JSONObject;
 
 import java.io.IOException;
+import java.util.concurrent.TimeUnit;
 
 public class FetchPlugin extends CordovaPlugin {
 
@@ -27,6 +28,8 @@ public class FetchPlugin extends CordovaPlugin {
 
     private final OkHttpClient mClient = new OkHttpClient();
     public static final MediaType MEDIA_TYPE_MARKDOWN = MediaType.parse("application/x-www-form-urlencoded; charset=utf-8");
+
+    private static final long DEFAULT_TIMEOUT = 10;
 
     @Override
     public boolean execute(final String action, final JSONArray data, final CallbackContext callbackContext) {
@@ -143,12 +146,24 @@ public class FetchPlugin extends CordovaPlugin {
                 callbackContext.error(e.getMessage());
             }
 
-        } else {
+        } 
+        else if (action.equals("setTimeout")) {
+            this.setTimeout(data.optLong(0, DEFAULT_TIMEOUT));
+        }
+        else {
             Log.e(LOG_TAG, "Invalid action : " + action);
             callbackContext.sendPluginResult(new PluginResult(PluginResult.Status.INVALID_ACTION));
             return false;
         }
 
         return true;
+    }
+
+    private void setTimeout(long seconds) {
+        Log.v(LOG_TAG, "setTimeout: " + seconds.toString());
+
+        mClient.setConnectTimeout(seconds, TimeUnit.SECONDS);
+        mClient.setReadTimeout(seconds, TimeUnit.SECONDS);
+        mClient.setWriteTimeout(seconds, TimeUnit.SECONDS);
     }
 }

--- a/src/android/com/adobe/phonegap/fetch/FetchPlugin.java
+++ b/src/android/com/adobe/phonegap/fetch/FetchPlugin.java
@@ -19,6 +19,7 @@ import org.json.JSONException;
 import org.json.JSONObject;
 
 import java.io.IOException;
+import java.util.concurrent.TimeUnit;
 
 public class FetchPlugin extends CordovaPlugin {
 
@@ -27,6 +28,8 @@ public class FetchPlugin extends CordovaPlugin {
 
     private final OkHttpClient mClient = new OkHttpClient();
     public static final MediaType MEDIA_TYPE_MARKDOWN = MediaType.parse("application/x-www-form-urlencoded; charset=utf-8");
+
+    private static final long DEFAULT_TIMEOUT = 10;
 
     @Override
     public boolean execute(final String action, final JSONArray data, final CallbackContext callbackContext) {
@@ -143,12 +146,24 @@ public class FetchPlugin extends CordovaPlugin {
                 callbackContext.error(e.getMessage());
             }
 
-        } else {
+        } 
+        else if (action.equals("setTimeout")) {
+            this.setTimeout(data.optLong(0, DEFAULT_TIMEOUT));
+        }
+        else {
             Log.e(LOG_TAG, "Invalid action : " + action);
             callbackContext.sendPluginResult(new PluginResult(PluginResult.Status.INVALID_ACTION));
             return false;
         }
 
         return true;
+    }
+
+    private void setTimeout(long seconds) {
+        Log.v(LOG_TAG, "setTimeout: " + seconds);
+
+        mClient.setConnectTimeout(seconds, TimeUnit.SECONDS);
+        mClient.setReadTimeout(seconds, TimeUnit.SECONDS);
+        mClient.setWriteTimeout(seconds, TimeUnit.SECONDS);
     }
 }

--- a/www/fetch.js
+++ b/www/fetch.js
@@ -29,7 +29,7 @@
   function Headers(headers) {
     this.map = {}
 
-    if (headers instanceof Headers) {
+    if (headers instanceof Headers || headers instanceof window.Headers) {
       headers.forEach(function(value, name) {
         this.append(name, value)
       }, this)

--- a/www/fetch.js
+++ b/www/fetch.js
@@ -29,7 +29,7 @@
   function Headers(headers) {
     this.map = {}
 
-    if (headers instanceof Headers) {
+    if (headers instanceof Headers || headers instanceof window.Headers) {
       headers.forEach(function(value, name) {
         this.append(name, value)
       }, this)
@@ -346,6 +346,14 @@
 
       }, "FetchPlugin", "fetch", [request.method, request.url, typeof request._bodyInit === 'undefined' ? null : request._bodyInit, request.headers]);
     })
+  }
+
+  /**
+   * Set timeout of the underlying http request
+   * @param timeout in seconds
+   */
+  cordovaFetch.fetch.setTimeout = function(timeout) {
+    exec(null, null, "FetchPlugin", "setTimeout", [timeout]);
   }
 
   cordovaFetch.fetch.polyfill = true

--- a/www/fetch.js
+++ b/www/fetch.js
@@ -348,6 +348,14 @@
     })
   }
 
+  /**
+   * Set timeout of the underlying http request
+   * @param timeout in seconds
+   */
+  cordovaFetch.fetch.setTimeout = function(timeout) {
+    exec(null, null, "FetchPlugin", "setTimeout", [timeout]);
+  }
+
   cordovaFetch.fetch.polyfill = true
 
   module.exports = cordovaFetch.fetch;


### PR DESCRIPTION
I'm using this plugin to replace windows.fetch so that I enable other libraries to invoke native fetch operations.

Because I am replacing windows.fetch with this plugin, the other libraries will be passing in windows.Header object which does not work with getOwnPropertyNames