### PR TITLE
Required for cordova-android 10.1.1

### DIFF
--- a/src/android/dependencies.gradle
+++ b/src/android/dependencies.gradle
@@ -1,4 +1,4 @@
-apply plugin: 'maven'
+apply plugin: 'maven-publish'
 
 repositories {
     mavenLocal()


### PR DESCRIPTION
Gradle 7 removed support for plugin maven

https://docs.gradle.org/7.0/userguide/upgrading_version_6.html#removal_of_the_legacy_maven_plugin