### PR TITLE
change removed Gradle compile configuration

### DIFF
--- a/src/android/dependencies.gradle
+++ b/src/android/dependencies.gradle
@@ -6,5 +6,5 @@ repositories {
 }
 
 dependencies {
-    compile 'com.squareup.okhttp3:okhttp:4.9.0'
+    implementation 'com.squareup.okhttp3:okhttp:4.9.0'
 }


### PR DESCRIPTION
The Gradle configuration "compile" used in this project has been removed as of Gradle version 3.4. This change fixes the removed configuration.

https://docs.gradle.org/current/userguide/upgrading_version_6.html#sec:configuration_removal
